### PR TITLE
Add usage comparison APIs and charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,8 @@ During development you can run `npm start` and separately `npm --prefix frontend
 - `POST /api/events` – log a feature usage event. Body parameters: `feature`, `user`, `account`, `location`.
 - `GET /api/usage` – retrieve aggregated counts per feature for a time range.
 - `GET /api/trend` – hourly counts for a single feature within a time range.
+- `GET /api/users` – aggregated counts grouped by user.
+- `GET /api/accounts` – aggregated counts grouped by account.
+- `GET /api/locations` – aggregated counts grouped by location.
 
 This prototype is intended to demonstrate the basic data flow and can be extended with authentication, additional filtering, and persistent storage.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,41 +1,14 @@
-import { Bar } from 'react-chartjs-2';
-import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
-  BarElement,
-  Title,
-  Tooltip,
-  Legend
-} from 'chart.js';
 import UsageList from './components/UsageList/UsageList.jsx';
+import UsageChart from './components/UsageChart/UsageChart.jsx';
 import './App.css';
-import { useEffect, useState } from 'react';
-
-ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
 function App() {
-  const [trendData, setTrendData] = useState([]);
-
-  useEffect(() => {
-    fetch('http://localhost:3000/api/usage')
-      .then(res => res.json())
-      .then(setTrendData)
-      .catch(console.error);
-  }, []);
-
-  const chartData = {
-    labels: trendData.map(r => r.feature),
-    datasets: [{
-      label: 'Usage count',
-      data: trendData.map(r => r.count),
-      backgroundColor: 'rgba(75,192,192,0.6)'
-    }]
-  };
-
   return (
     <div className="App">
-      <Bar data={chartData} />
+      <UsageChart title="Feature Usage" endpoint="/api/usage" labelKey="feature" />
+      <UsageChart title="Usage by User" endpoint="/api/users" labelKey="user" />
+      <UsageChart title="Usage by Account" endpoint="/api/accounts" labelKey="account" />
+      <UsageChart title="Usage by Location" endpoint="/api/locations" labelKey="location" />
       <UsageList />
     </div>
   );

--- a/client/src/components/UsageChart/UsageChart.jsx
+++ b/client/src/components/UsageChart/UsageChart.jsx
@@ -1,0 +1,34 @@
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
+import { useEffect, useState } from 'react';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+function UsageChart({ title, endpoint, labelKey }) {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    fetch(`http://localhost:3000${endpoint}`)
+      .then(res => res.json())
+      .then(setData)
+      .catch(console.error);
+  }, [endpoint]);
+
+  const chartData = {
+    labels: data.map(r => r[labelKey]),
+    datasets: [{
+      label: title,
+      data: data.map(r => r.count),
+      backgroundColor: 'rgba(75,192,192,0.6)'
+    }]
+  };
+
+  return (
+    <div>
+      <h2>{title}</h2>
+      <Bar data={chartData} />
+    </div>
+  );
+}
+
+export default UsageChart;

--- a/client/src/components/UsageChart/UsageChart.test.jsx
+++ b/client/src/components/UsageChart/UsageChart.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import UsageChart from './UsageChart.jsx';
+
+vi.mock('react-chartjs-2', () => ({ Bar: () => <div>chart</div> }));
+
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve([]) })));
+
+describe('UsageChart', () => {
+  test('renders title', () => {
+    render(<UsageChart title="Test" endpoint="/test" labelKey="user" />);
+    expect(screen.getByText('Test')).toBeInTheDocument();
+  });
+});

--- a/server/controllers/events.js
+++ b/server/controllers/events.js
@@ -44,4 +44,51 @@ function trend(req, res) {
   res.json(rows);
 }
 
-module.exports = { logEvent, usage, trend, listEvents };
+function usageByUser(req, res) {
+  const { start, end, feature } = req.query;
+  const startDate = start ? new Date(start) : new Date(Date.now() - 24*60*60*1000);
+  const endDate = end ? new Date(end) : new Date();
+  const params = {
+    start: startDate.toISOString().slice(0, 19).replace('T', ' '),
+    end: endDate.toISOString().slice(0, 19).replace('T', ' '),
+    feature: feature ? `%${feature}%` : '%'
+  };
+  const rows = db.getUsageByUser(params);
+  res.json(rows);
+}
+
+function usageByAccount(req, res) {
+  const { start, end, feature } = req.query;
+  const startDate = start ? new Date(start) : new Date(Date.now() - 24*60*60*1000);
+  const endDate = end ? new Date(end) : new Date();
+  const params = {
+    start: startDate.toISOString().slice(0, 19).replace('T', ' '),
+    end: endDate.toISOString().slice(0, 19).replace('T', ' '),
+    feature: feature ? `%${feature}%` : '%'
+  };
+  const rows = db.getUsageByAccount(params);
+  res.json(rows);
+}
+
+function usageByLocation(req, res) {
+  const { start, end, feature } = req.query;
+  const startDate = start ? new Date(start) : new Date(Date.now() - 24*60*60*1000);
+  const endDate = end ? new Date(end) : new Date();
+  const params = {
+    start: startDate.toISOString().slice(0, 19).replace('T', ' '),
+    end: endDate.toISOString().slice(0, 19).replace('T', ' '),
+    feature: feature ? `%${feature}%` : '%'
+  };
+  const rows = db.getUsageByLocation(params);
+  res.json(rows);
+}
+
+module.exports = {
+  logEvent,
+  usage,
+  trend,
+  listEvents,
+  usageByUser,
+  usageByAccount,
+  usageByLocation
+};

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -73,9 +73,48 @@ function getTrend({ feature, start, end }) {
   return stmt.all(feature, start, end);
 }
 
+function getUsageByUser({ start, end, feature = '%' }) {
+  const stmt = db.prepare(`
+    SELECT COALESCE(user, 'Unknown') as user, COUNT(e.id) as count
+    FROM events e JOIN features f ON f.id = e.feature_id
+    WHERE e.timestamp BETWEEN ? AND ?
+      AND f.name LIKE ?
+    GROUP BY user
+    ORDER BY count DESC
+  `);
+  return stmt.all(start, end, feature);
+}
+
+function getUsageByAccount({ start, end, feature = '%' }) {
+  const stmt = db.prepare(`
+    SELECT COALESCE(account, 'Unknown') as account, COUNT(e.id) as count
+    FROM events e JOIN features f ON f.id = e.feature_id
+    WHERE e.timestamp BETWEEN ? AND ?
+      AND f.name LIKE ?
+    GROUP BY account
+    ORDER BY count DESC
+  `);
+  return stmt.all(start, end, feature);
+}
+
+function getUsageByLocation({ start, end, feature = '%' }) {
+  const stmt = db.prepare(`
+    SELECT COALESCE(location, 'Unknown') as location, COUNT(e.id) as count
+    FROM events e JOIN features f ON f.id = e.feature_id
+    WHERE e.timestamp BETWEEN ? AND ?
+      AND f.name LIKE ?
+    GROUP BY location
+    ORDER BY count DESC
+  `);
+  return stmt.all(start, end, feature);
+}
+
 module.exports = {
   insertEvent,
   getUsage,
   getEvents,
-  getTrend
+  getTrend,
+  getUsageByUser,
+  getUsageByAccount,
+  getUsageByLocation
 };

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -6,5 +6,8 @@ router.post('/events', ctrl.logEvent);
 router.get('/usage', ctrl.usage);
 router.get('/trend', ctrl.trend);
 router.get('/events', ctrl.listEvents);
+router.get('/users', ctrl.usageByUser);
+router.get('/accounts', ctrl.usageByAccount);
+router.get('/locations', ctrl.usageByLocation);
 
 module.exports = router;

--- a/server/test/api.test.js
+++ b/server/test/api.test.js
@@ -15,4 +15,22 @@ describe('API', () => {
     expect(res.statusCode).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
   });
+
+  test('GET /api/users returns data', async () => {
+    const res = await request(app).get('/api/users');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  test('GET /api/accounts returns data', async () => {
+    const res = await request(app).get('/api/accounts');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  test('GET /api/locations returns data', async () => {
+    const res = await request(app).get('/api/locations');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- provide aggregated usage APIs grouped by user, account and location
- document new endpoints
- add generic `UsageChart` React component
- show multiple comparison charts in the app
- expand API tests for new routes
- add tests for the new chart component

## Testing
- `npm test --silent` in `server`
- `npm test --silent` in `client`

------
https://chatgpt.com/codex/tasks/task_e_685c39ed5af4832282e9a8d74c9be6aa