### PR TITLE
Add pie and line charts

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,7 @@
 import UsageList from './components/UsageList/UsageList.jsx';
 import UsageChart from './components/UsageChart/UsageChart.jsx';
+import PieChart from './components/PieChart/PieChart.jsx';
+import TrendChart from './components/TrendChart/TrendChart.jsx';
 import './App.css';
 
 function App() {
@@ -9,6 +11,8 @@ function App() {
       <UsageChart title="Usage by User" endpoint="/api/users" labelKey="user" />
       <UsageChart title="Usage by Account" endpoint="/api/accounts" labelKey="account" />
       <UsageChart title="Usage by Location" endpoint="/api/locations" labelKey="location" />
+      <PieChart title="Usage Distribution" endpoint="/api/usage" labelKey="feature" />
+      <TrendChart feature="Tracking" />
       <UsageList />
     </div>
   );

--- a/client/src/components/PieChart/PieChart.jsx
+++ b/client/src/components/PieChart/PieChart.jsx
@@ -1,0 +1,42 @@
+import { Pie } from 'react-chartjs-2';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+import { useEffect, useState } from 'react';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+function PieChart({ title, endpoint, labelKey }) {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    fetch(`http://localhost:3000${endpoint}`)
+      .then(res => res.json())
+      .then(setData)
+      .catch(console.error);
+  }, [endpoint]);
+
+  const chartData = {
+    labels: data.map(r => r[labelKey]),
+    datasets: [
+      {
+        data: data.map(r => r.count),
+        backgroundColor: [
+          'rgba(75,192,192,0.6)',
+          'rgba(54,162,235,0.6)',
+          'rgba(255,206,86,0.6)',
+          'rgba(255,99,132,0.6)',
+          'rgba(153,102,255,0.6)',
+          'rgba(201,203,207,0.6)'
+        ]
+      }
+    ]
+  };
+
+  return (
+    <div>
+      <h2>{title}</h2>
+      <Pie data={chartData} />
+    </div>
+  );
+}
+
+export default PieChart;

--- a/client/src/components/PieChart/PieChart.test.jsx
+++ b/client/src/components/PieChart/PieChart.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import PieChart from './PieChart.jsx';
+
+vi.mock('react-chartjs-2', () => ({ Pie: () => <div>piechart</div> }));
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve([]) })));
+
+describe('PieChart', () => {
+  test('renders title', () => {
+    render(<PieChart title="Test Pie" endpoint="/test" labelKey="feature" />);
+    expect(screen.getByText('Test Pie')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/TrendChart/TrendChart.jsx
+++ b/client/src/components/TrendChart/TrendChart.jsx
@@ -1,0 +1,40 @@
+import { Line } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend } from 'chart.js';
+import { useEffect, useState } from 'react';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+function TrendChart({ feature }) {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    if (!feature) return;
+    const params = new URLSearchParams({ feature });
+    fetch(`http://localhost:3000/api/trend?${params.toString()}`)
+      .then(res => res.json())
+      .then(setData)
+      .catch(console.error);
+  }, [feature]);
+
+  const chartData = {
+    labels: data.map(r => r.hour),
+    datasets: [
+      {
+        label: `${feature} Usage`,
+        data: data.map(r => r.count),
+        borderColor: 'rgba(75,192,192,1)',
+        backgroundColor: 'rgba(75,192,192,0.2)',
+        tension: 0.3
+      }
+    ]
+  };
+
+  return (
+    <div>
+      <h2>{feature} Trend</h2>
+      <Line data={chartData} />
+    </div>
+  );
+}
+
+export default TrendChart;

--- a/client/src/components/TrendChart/TrendChart.test.jsx
+++ b/client/src/components/TrendChart/TrendChart.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import TrendChart from './TrendChart.jsx';
+
+vi.mock('react-chartjs-2', () => ({ Line: () => <div>linechart</div> }));
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve([]) })));
+
+describe('TrendChart', () => {
+  test('renders feature name', () => {
+    render(<TrendChart feature="TestFeature" />);
+    expect(screen.getByText(/TestFeature Trend/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a PieChart component
- add a TrendChart component
- show new charts in the app
- test the new components

## Testing
- `npm --prefix server test`
- `npm --prefix client test`


------
https://chatgpt.com/codex/tasks/task_e_685c437367ac8322b3e403d7ef23e860