### PR TITLE
Add overlay lines for feature trend chart

### DIFF
--- a/client/src/components/TrendChart/TrendChart.test.jsx
+++ b/client/src/components/TrendChart/TrendChart.test.jsx
@@ -6,8 +6,9 @@ vi.mock('react-chartjs-2', () => ({ Line: () => <div>linechart</div> }));
 vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve([]) })));
 
 describe('TrendChart', () => {
-  test('renders feature name', () => {
+  test('renders feature name and fetches data for all features', () => {
     render(<TrendChart feature="TestFeature" />);
     expect(screen.getByText(/TestFeature Trend/)).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary
- overlay trend lines for all features instead of just one
- update test to verify fetch calls for each feature

## Testing
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test -- --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c45312d308322bee9b52b3d8a26e9