### PR TITLE
Show feature usage breakdown

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,6 @@
 import UsageList from './components/UsageList/UsageList.jsx';
 import UsageChart from './components/UsageChart/UsageChart.jsx';
+import FeatureBreakdownChart from './components/FeatureBreakdownChart/FeatureBreakdownChart.jsx';
 import PieChart from './components/PieChart/PieChart.jsx';
 import TrendChart from './components/TrendChart/TrendChart.jsx';
 import './App.css';
@@ -7,7 +8,7 @@ import './App.css';
 function App() {
   return (
     <div className="App">
-      <UsageChart title="Feature Usage" endpoint="/api/usage" labelKey="feature" />
+      <FeatureBreakdownChart />
       <UsageChart title="Usage by User" endpoint="/api/users" labelKey="user" />
       <UsageChart title="Usage by Account" endpoint="/api/accounts" labelKey="account" />
       <UsageChart title="Usage by Location" endpoint="/api/locations" labelKey="location" />

--- a/client/src/components/FeatureBreakdownChart/FeatureBreakdownChart.jsx
+++ b/client/src/components/FeatureBreakdownChart/FeatureBreakdownChart.jsx
@@ -1,0 +1,101 @@
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
+import { useEffect, useState } from 'react';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+const userColors = ['rgba(75,192,192,0.6)', 'rgba(54,162,235,0.6)', 'rgba(255,206,86,0.6)'];
+const accountColors = ['rgba(255,99,132,0.6)', 'rgba(153,102,255,0.6)', 'rgba(201,203,207,0.6)'];
+const locationColors = ['rgba(255,159,64,0.6)', 'rgba(99,255,132,0.6)', 'rgba(255,205,86,0.6)'];
+const totalColor = 'rgba(0,0,0,0.8)';
+
+function FeatureBreakdownChart() {
+  const [chartData, setChartData] = useState({ labels: [], datasets: [] });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const usageRes = await fetch('http://localhost:3000/api/usage');
+      const usage = await usageRes.json();
+      const features = usage.map(u => u.feature);
+      const dataMap = {};
+      for (const f of features) {
+        const [usersRes, accountsRes, locationsRes] = await Promise.all([
+          fetch(`http://localhost:3000/api/users?feature=${encodeURIComponent(f)}`),
+          fetch(`http://localhost:3000/api/accounts?feature=${encodeURIComponent(f)}`),
+          fetch(`http://localhost:3000/api/locations?feature=${encodeURIComponent(f)}`)
+        ]);
+        const [users, accounts, locations] = await Promise.all([
+          usersRes.json(),
+          accountsRes.json(),
+          locationsRes.json()
+        ]);
+        const total = usage.find(u => u.feature === f)?.count || 0;
+        dataMap[f] = { total, users, accounts, locations };
+      }
+
+      const labels = features;
+      const datasets = [];
+      features.forEach((feature, idx) => {
+        const d = dataMap[feature];
+        const baseArray = new Array(features.length).fill(0);
+        const totalData = baseArray.slice();
+        totalData[idx] = d.total;
+        datasets.push({
+          label: `${feature} Total`,
+          stack: `${feature}-total`,
+          data: totalData,
+          backgroundColor: totalColor
+        });
+        d.users.forEach((u, uIdx) => {
+          const arr = baseArray.slice();
+          arr[idx] = u.count;
+          datasets.push({
+            label: `${feature} User: ${u.user}`,
+            stack: `${feature}-user`,
+            data: arr,
+            backgroundColor: userColors[uIdx % userColors.length]
+          });
+        });
+        d.accounts.forEach((a, aIdx) => {
+          const arr = baseArray.slice();
+          arr[idx] = a.count;
+          datasets.push({
+            label: `${feature} Account: ${a.account}`,
+            stack: `${feature}-account`,
+            data: arr,
+            backgroundColor: accountColors[aIdx % accountColors.length]
+          });
+        });
+        d.locations.forEach((l, lIdx) => {
+          const arr = baseArray.slice();
+          arr[idx] = l.count;
+          datasets.push({
+            label: `${feature} Location: ${l.location}`,
+            stack: `${feature}-location`,
+            data: arr,
+            backgroundColor: locationColors[lIdx % locationColors.length]
+          });
+        });
+      });
+
+      setChartData({ labels, datasets });
+    };
+
+    fetchData().catch(console.error);
+  }, []);
+
+  const options = {
+    responsive: true,
+    plugins: { legend: { position: 'bottom' } },
+    scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } }
+  };
+
+  return (
+    <div>
+      <h2>Feature Usage</h2>
+      <Bar data={chartData} options={options} />
+    </div>
+  );
+}
+
+export default FeatureBreakdownChart;

--- a/client/src/components/FeatureBreakdownChart/FeatureBreakdownChart.test.jsx
+++ b/client/src/components/FeatureBreakdownChart/FeatureBreakdownChart.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import FeatureBreakdownChart from './FeatureBreakdownChart.jsx';
+
+vi.mock('react-chartjs-2', () => ({ Bar: () => <div>chart</div> }));
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve([]) })));
+
+describe('FeatureBreakdownChart', () => {
+  test('renders title', () => {
+    render(<FeatureBreakdownChart />);
+    expect(screen.getByText('Feature Usage')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- replace `UsageChart` with `FeatureBreakdownChart` in the app
- create `FeatureBreakdownChart` component that loads usage by user, account and location for each feature
- add tests for the new chart

## Testing
- `npm test` in `client`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_685c57c93b14832294e64f01b94d1396