### PR TITLE
Modify init db to truncate tables

### DIFF
--- a/server/db/index.js
+++ b/server/db/index.js
@@ -19,7 +19,12 @@ CREATE TABLE IF NOT EXISTS events (
   FOREIGN KEY(feature_id) REFERENCES features(id)
 );`;
 
-db.exec(init);
+function initDb() {
+  db.exec(init);
+  db.exec('DELETE FROM events; DELETE FROM features;');
+}
+
+initDb();
 
 const getFeatureId = db.prepare('SELECT id FROM features WHERE name = ?');
 const insertFeature = db.prepare('INSERT INTO features(name) VALUES (?)');
@@ -79,6 +84,7 @@ function getTrend({ feature, start, end }) {
 }
 
 module.exports = {
+  initDb,
   insertEvent,
   getUsage,
   getEvents,


### PR DESCRIPTION
## Summary
- reset event & feature tables whenever the DB initializes

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_685c797aba008322a22691fa639cf710