### PR TITLE
Add truncation script

### DIFF
--- a/server/db/index.js
+++ b/server/db/index.js
@@ -21,6 +21,9 @@ CREATE TABLE IF NOT EXISTS events (
 
 function initDb() {
   db.exec(init);
+}
+
+function truncateEvents() {
   db.exec('DELETE FROM events; DELETE FROM features;');
 }
 
@@ -85,6 +88,7 @@ function getTrend({ feature, start, end }) {
 
 module.exports = {
   initDb,
+  truncateEvents,
   insertEvent,
   getUsage,
   getEvents,

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
     "build": "cd ../client && npm install && npm run build",
     "dev": "nodemon index.js",
     "test": "jest",
-    "seed": "node scripts/seed.js"
+    "seed": "node scripts/seed.js",
+    "truncate": "node scripts/truncate.js"
   },
   "dependencies": {
     "better-sqlite3": "^12.0.0",

--- a/server/scripts/truncate.js
+++ b/server/scripts/truncate.js
@@ -1,0 +1,8 @@
+const { truncateEvents } = require('../db');
+
+if (require.main === module) {
+  truncateEvents();
+  console.log('Truncated events and features tables');
+}
+
+module.exports = { truncateEvents };


### PR DESCRIPTION
## Summary
- move table-clearing logic out of DB init
- add `truncateEvents` helper and script
- expose new script via npm scripts

## Testing
- `npm --prefix server test`


------
https://chatgpt.com/codex/tasks/task_e_685c8542cc348322a7a4a47bf64c1bf7